### PR TITLE
refactor(spinner): Cambia a exportación por defecto para resolver error

### DIFF
--- a/frontend/src/features/roles/components/HistorialRolModal.jsx
+++ b/frontend/src/features/roles/components/HistorialRolModal.jsx
@@ -1,7 +1,7 @@
 // src/features/roles/components/HistorialRolModal.jsx
 import React from 'react';
 import Modal from '../../../shared/components/common/Modal';
-import { Spinner } from '../../../shared/components/common/Spinner'; // Importación corregida
+import Spinner from '../../../shared/components/common/Spinner'; // Importación corregida
 import { FaTimes, FaUserCircle } from 'react-icons/fa';
 import '../css/HistorialRolModal.css';
 

--- a/frontend/src/shared/components/common/Spinner.jsx
+++ b/frontend/src/shared/components/common/Spinner.jsx
@@ -2,6 +2,8 @@
 import React from 'react';
 import './Spinner.css';
 
-export const Spinner = () => {
+const Spinner = () => {
   return <div className="spinner"></div>;
 };
+
+export default Spinner;


### PR DESCRIPTION
Se cambió el componente Spinner para que utilice una exportación por defecto en lugar de una exportación nombrada. La importación correspondiente en `HistorialRolModal.jsx` ha sido actualizada para coincidir.

Este cambio se realizó para solucionar un error persistente de resolución de módulos que ocurría en el entorno, a pesar de que el código para importaciones/exportaciones nombradas era sintácticamente correcto. Cambiar a importaciones por defecto proporciona una alternativa que parece resolver el problema subyacente, posiblemente relacionado con la herramienta de construcción o la caché.